### PR TITLE
Added action after build, that deletes obj/ in project folder (тупая визуалка!!!!!)

### DIFF
--- a/suai-bot-api-gateway.csproj
+++ b/suai-bot-api-gateway.csproj
@@ -12,14 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Domain\TeacherInfo\Protos\TeacherInfoService.proto" />
-    <None Remove="Domain\TimeTable\Protos\LessonTypes.proto" />
-    <None Remove="Domain\TimeTable\Protos\TimeTableService.proto" />
-    <None Remove="Domain\TimeTable\Protos\WeekDays.proto" />
-    <None Remove="Domain\TimeTable\Protos\WeekTypes.proto" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
   </ItemGroup>
 
@@ -47,5 +39,9 @@
   <ItemGroup>
     <Folder Include="Models\TeacherInfo\" />
   </ItemGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition=" '$(OS)' == 'Windows_NT'">
+	  <Exec Command="rd &quot;$(ProjectDir)obj&quot; /s /q" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
Для корректного билда в докере я вынес файлы сборки из проекта, но визуалка упорно продолжает спавнить мне obj в папку с проектом, а это крашит докер.
Использовал решение с официального сайта (с поправкой, что команда выполняется только на винде)
![image](https://user-images.githubusercontent.com/86615975/167150507-3a5c6095-886c-4649-88d1-a1ad9361414c.png)
